### PR TITLE
[WIP] PN-20633: mark timeline element COURTESY_CHANNEL_FAILED as diagnostic

### DIFF
--- a/docs/openapi/schemas-pn-timeline.yaml
+++ b/docs/openapi/schemas-pn-timeline.yaml
@@ -64,6 +64,7 @@ components:
       #   * `ANALOG_FAILURE_WORKFLOW_TIMEOUT` - Completato con fallimento il workflow di invio cartaceo per l'assenza di esiti per ogni tentativo di spedizione nell'intervallo temporale stabilito  # NO EXTERNAL
       #   * `NOTIFICATION_COST_VALIDATION_REQUEST` - Invio richiesta di validazione del costo della notifica per una notifica # NO EXTERNAL
       #   * `NOTIFICATION_COST_VALIDATION_RESPONSE` - Ricezione risposta di validazione del costo della notifica per una notifica # NO EXTERNAL
+      #   * `COURTESY_CHANNEL_FAILED` - Fallimento dell'invio del messaggio di cortesia su un canale # NO EXTERNAL
       enum:
         - SENDER_ACK_CREATION_REQUEST
         - VALIDATE_NORMALIZE_ADDRESSES_REQUEST

--- a/src/main/java/it/pagopa/pn/stream/dto/TimelineElementCategoryInt.java
+++ b/src/main/java/it/pagopa/pn/stream/dto/TimelineElementCategoryInt.java
@@ -61,7 +61,8 @@ public enum TimelineElementCategoryInt {
     ANALOG_FAILURE_WORKFLOW_TIMEOUT(TimelineElementCategoryInt.VERSION_27),
     NOTIFICATION_TIMELINE_REWORKED(TimelineElementCategoryInt.VERSION_28),
     NOTIFICATION_COST_VALIDATION_REQUEST(TimelineElementCategoryInt.VERSION_28),
-    NOTIFICATION_COST_VALIDATION_RESPONSE(TimelineElementCategoryInt.VERSION_28);
+    NOTIFICATION_COST_VALIDATION_RESPONSE(TimelineElementCategoryInt.VERSION_28),
+    COURTESY_CHANNEL_FAILED(TimelineElementCategoryInt.VERSION_28);
 
 
     private final int version;
@@ -90,7 +91,8 @@ public enum TimelineElementCategoryInt {
         SEND_ANALOG_TIMEOUT,
         ANALOG_FAILURE_WORKFLOW_TIMEOUT,
         NOTIFICATION_COST_VALIDATION_REQUEST,
-        NOTIFICATION_COST_VALIDATION_RESPONSE
+        NOTIFICATION_COST_VALIDATION_RESPONSE,
+        COURTESY_CHANNEL_FAILED
     }
 
     public enum UnlockTimelineElementCategory {

--- a/src/test/java/it/pagopa/pn/stream/service/impl/EventsServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/stream/service/impl/EventsServiceImplTest.java
@@ -1082,6 +1082,46 @@ class EventsServiceImplTest {
         Mockito.verify(schedulerService, never()).scheduleSortEvent(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
+    @Test
+    void saveEventDiagnosticElementIsSkipped() {
+        //GIVEN
+        String xpagopacxid = "PA-xpagopacxid";
+        String iun = "IUN-ABC-FGHI-A-1";
+
+        List<StreamEntity> list = new ArrayList<>();
+        StreamEntity entity = new StreamEntity();
+        entity.setStreamId(UUID.randomUUID().toString());
+        entity.setTitle("1");
+        entity.setPaId(xpagopacxid);
+        entity.setEventType(StreamMetadataResponseV29.EventTypeEnum.TIMELINE.toString());
+        entity.setFilterValues(new HashSet<>());
+        entity.setActivationDate(Instant.now());
+        entity.setEventAtomicCounter(1L);
+        entity.setVersion("V10");
+        list.add(entity);
+
+        TimelineElementInternal newtimeline = TimelineElementInternal.builder()
+                .category(TimelineElementCategoryInt.COURTESY_CHANNEL_FAILED.name())
+                .iun(iun)
+                .timelineElementId(iun + "_" + TimelineElementCategoryInt.COURTESY_CHANNEL_FAILED)
+                .statusInfo(StatusInfoInternal.builder().actual("ACCEPTED").statusChanged(true).build())
+                .timestamp(Instant.now())
+                .paId(xpagopacxid)
+                .build();
+
+        StreamNotificationEntity notificationInt = new StreamNotificationEntity();
+
+        Mockito.when(streamEntityDao.findByPa(xpagopacxid)).thenReturn(Flux.fromIterable(list));
+        Mockito.when(streamNotificationDao.findByIun(Mockito.anyString())).thenReturn(Mono.just(notificationInt));
+
+        webhookEventsService.saveEvent(newtimeline).block(d);
+
+        //THEN
+        Mockito.verify(streamEntityDao).findByPa(xpagopacxid);
+        Mockito.verify(eventEntityDao, never()).save(Mockito.any(EventEntity.class));
+        Mockito.verify(streamEntityDao, never()).updateAndGetAtomicCounter(Mockito.any());
+    }
+
 
     @Test
     void saveEventFiltered() {


### PR DESCRIPTION
Added COURTESY_CHANNEL_FAILED to the TimelineElementCategoryInt enum and to its DiagnosticTimelineElementCategory inner class, so it is recognized as a diagnostic element to be used only for internal purposes. Updated the TimelineElementCategoryV28 schema description in the diagnostic categories section. Added a test covering that a diagnostic element is skipped on save.